### PR TITLE
Loot table refactoring

### DIFF
--- a/src/simulation/monsters/bosses/Vorkath.ts
+++ b/src/simulation/monsters/bosses/Vorkath.ts
@@ -1,4 +1,4 @@
-import { roll } from 'e';
+//import { roll } from 'e';
 
 import { ItemBank } from '../../../meta/types';
 import Bank from '../../../structures/Bank';
@@ -63,6 +63,15 @@ const VorkathTable = new LootTable()
 	.add('Dragonstone', [2, 3], 3)
 	.add('Wrath talisman', 1, 3);
 
+const VorkathTertiaryTable = new LootTable()
+	.tertiary(50, 21907) // Vorkath's head, exists twice, this is the head with 50k worth
+	.tertiary(65, 'Clue scroll (elite)')
+	.tertiary(1000, 'Dragonbone necklace')
+	.tertiary(3000, 'Jar of decay')
+	.tertiary(3000, 'Vorki')
+	.tertiary(5000, 'Draconic visage')
+	.tertiary(5000, 'Skeletal visage');
+
 export class Vorkath extends SimpleMonster {
 	public kill(quantity = 1): ItemBank {
 		const loot = new Bank();
@@ -71,13 +80,15 @@ export class Vorkath extends SimpleMonster {
 			loot.add(VorkathTable.roll());
 			loot.add(VorkathTable.roll());
 
-			if (roll(50)) loot.add("Vorkath's head");
-			if (roll(65)) loot.add('Clue scroll (elite)');
-			if (roll(1000)) loot.add('Dragonbone necklace');
-			if (roll(3000)) loot.add('Jar of decay');
-			if (roll(3000)) loot.add('Vorki');
-			if (roll(5000)) loot.add('Draconic visage');
-			if (roll(5000)) loot.add('Skeletal visage');
+			loot.add(VorkathTertiaryTable.roll());
+
+			// if (roll(50)) loot.add("Vorkath's head");
+			// if (roll(65)) loot.add('Clue scroll (elite)');
+			// if (roll(1000)) loot.add('Dragonbone necklace');
+			// if (roll(3000)) loot.add('Jar of decay');
+			// if (roll(3000)) loot.add('Vorki');
+			// if (roll(5000)) loot.add('Draconic visage');
+			// if (roll(5000)) loot.add('Skeletal visage');
 		}
 
 		return loot.values();
@@ -87,6 +98,6 @@ export class Vorkath extends SimpleMonster {
 export default new Vorkath({
 	id: 8061,
 	name: 'Vorkath',
-	table: VorkathTable,
+	table: new LootTable().add(VorkathTable).add(VorkathTertiaryTable),
 	aliases: ['vorkath', 'vorki', 'vork']
 });

--- a/src/simulation/monsters/bosses/Zulrah.ts
+++ b/src/simulation/monsters/bosses/Zulrah.ts
@@ -1,4 +1,4 @@
-import { randInt, roll } from 'e';
+import { randInt } from 'e';
 
 import { ItemBank } from '../../../meta/types';
 import Bank from '../../../structures/Bank';
@@ -69,6 +69,11 @@ const ZulrahTable = new LootTable()
 	.add('Swamp tar', 1000, 5)
 	.add("Zulrah's scales", 500, 5);
 
+const ZulrahTertiaryTable = new LootTable()
+	.tertiary(75, 'Clue scroll (elite)')
+	.tertiary(3000, 'Jar of swamp')
+	.tertiary(4000, 'Pet snakeling');
+
 export class Zulrah extends SimpleMonster {
 	public kill(quantity = 1): ItemBank {
 		const loot = new Bank();
@@ -78,9 +83,11 @@ export class Zulrah extends SimpleMonster {
 			loot.add(ZulrahTable.roll());
 
 			loot.add("Zulrah's scales", randInt(100, 299));
-			if (roll(75)) loot.add('Clue scroll (elite)');
-			if (roll(3000)) loot.add('Jar of swamp');
-			if (roll(4000)) loot.add('Pet snakeling');
+
+			loot.add(ZulrahTertiaryTable.roll());
+			// if (roll(75)) loot.add('Clue scroll (elite)');
+			// if (roll(3000)) loot.add('Jar of swamp');
+			// if (roll(4000)) loot.add('Pet snakeling');
 		}
 
 		return loot.values();

--- a/src/simulation/monsters/bosses/Zulrah.ts
+++ b/src/simulation/monsters/bosses/Zulrah.ts
@@ -85,6 +85,7 @@ export class Zulrah extends SimpleMonster {
 			loot.add("Zulrah's scales", randInt(100, 299));
 
 			loot.add(ZulrahTertiaryTable.roll());
+			
 			// if (roll(75)) loot.add('Clue scroll (elite)');
 			// if (roll(3000)) loot.add('Jar of swamp');
 			// if (roll(4000)) loot.add('Pet snakeling');
@@ -97,6 +98,6 @@ export class Zulrah extends SimpleMonster {
 export default new Zulrah({
 	id: 2042,
 	name: 'Zulrah',
-	table: ZulrahTable,
+	table: new LootTable().add(ZulrahTable).add(ZulrahTertiaryTable),
 	aliases: ['zulrah', 'snek', 'zul']
 });

--- a/src/simulation/monsters/special/Barrows.ts
+++ b/src/simulation/monsters/special/Barrows.ts
@@ -3,7 +3,7 @@ import { roll } from 'e';
 import { ItemBank } from '../../../meta/types';
 import Bank from '../../../structures/Bank';
 import LootTable from '../../../structures/LootTable';
-import Monster from '../../../structures/Monster';
+import SimpleMonster from '../../../structures/SimpleMonster';
 
 const BarrowsTable = new LootTable();
 
@@ -51,7 +51,7 @@ const OtherTable = new LootTable()
 
 const NUMBER_OF_BROTHERS = 6;
 
-export class Barrows extends Monster {
+export class Barrows extends SimpleMonster {
 	public kill(quantity = 1): ItemBank {
 		const loot = new Bank();
 
@@ -82,4 +82,9 @@ export class Barrows extends Monster {
 }
 
 // Uses NPC id for Dharoks
-export default new Barrows({ id: 1673, name: 'Barrows', aliases: ['barrows'] });
+export default new Barrows({ 
+	id: 1673,
+	name: 'Barrows',
+	table: new LootTable().add(BarrowsTable).add(OtherTable),
+	aliases: ['barrows']
+ });


### PR DESCRIPTION
### Description:

-   Refactorings to Zulrah, Vorkath to bring their unique drops in line with the LootTable update. Closes oldschoolgg/oldschoolbot#915

-   Refactorings to Barrows, updating Barrows from a Monster to SimpleMonster. resolves oldschoolgg/oldschoolbot#866
### Changes:

-   Create tertiary LootTable for Zulrah
-   Create tertiary LootTable for Vorkath
-   Combine normal LootTable with the tertiary table for a total monster drop table without affecting kill results.
-   Change Barrows from Monster to SimpleMonster
-   Add table property to barrows
-   Combine unique and other drops LootTables for a total barrows drop table without affecting kill results. 

-   [x] I have tested all my changes thoroughly.
